### PR TITLE
Fix absolute paths; mcu USB config; stepper positioning

### DIFF
--- a/KlipperConfig/autoz.cfg
+++ b/KlipperConfig/autoz.cfg
@@ -1,0 +1,97 @@
+##### WARNING! ZButton PA0 is not configured here. Skript under DEV. Could harm your device!
+
+[z_calibration]
+
+# default from home_xy_position of safe_z_home
+nozzle_xy_position: 40, 190
+#   A X, Y coordinate (e.g. 100,100) of the nozzle, clicking on the z endstop.
+switch_xy_position: 64.10, 238.80
+#   A X, Y coordinate (e.g. 100,100) of the probe's switch body, clicking on
+#   the z endstop.
+switch_xy_offsets: -24.10, -48.80
+#   Instead of an absolute position (switch_xy_position), this configuration
+#   adds an X, Y offset (e.g. -6,-18) to the nozzle position.
+bed_xy_position: 115, 115
+#   A X, Y coordinate (e.g. 100,100) where the print surface (e.g. the center
+#   point) is probed. These coordinates are adjusted by the
+#   probe's X and Y offsets. The default is the zero_reference_position which
+#   replaces the deprecated relative_reference_index
+#   of the configured bed_mesh, if configured. It's possible to change the zero
+#   reference position at runtime or use the GCode argument BED_POSITION of CALIBRATE_Z.
+wiggle_xy_offsets: 0,0
+#   After probing the nozzle and retracting, move x some distance away and
+#   back. Useful to prevent the z endstop pin sticking to the nozzle and
+#   being pulled out of the assembly. Can be negative. Defaults to zero to
+#   disable it. Can be combined in x and y to move diagonally. Be careful
+#   to not move your nozzle out of range!
+switch_offset: 0.10
+#   The trigger point offset of the used mag-probe switch.
+#   A larger value will position the nozzle closer to the bed.
+#   This must be determined manually. More on this later
+#   in this section..
+offset_margins: -1.0,1.0
+#   The minimum and maximum margins allowed for the calculated offset.
+#   If the offset is outside these values, it will stop!
+#   The margin can be defined as "min,max" e.g. "-0.5,1.5" or by just one
+#   value e.g. "1.0" which translates to "-1.0,1.0" (which is also the default).
+# max_deviation: DEPRECATED - please use offset_margins instead!
+#   The maximum allowed deviation of the calculated offset.
+#   If the offset exceeds this value, it will stop!
+#   The default is 1.0 mm.
+# samples: default from "probe:samples" section
+#   The number of times to probe each point. The probed z-values
+#   will be averaged. The default is from the probe's configuration.
+# samples_tolerance: default from "probe:samples_tolerance" section
+#   The maximum Z distance (in mm) that a sample may differ from other
+#   samples. The default is from the probe's configuration.
+# samples_tolerance_retries: default from "probe:samples_tolerance_retries" section
+#   The number of times to retry if a sample is found that exceeds
+#   samples_tolerance. The default is from the probe's configuration.
+# samples_result: default from "probe:samples_result" section
+#   The calculation method when sampling more than once - either
+#   "median" or "average". The default is from the probe's configuration.
+# safe_z_height: default is 2 * z_offset from the "probe:z_offset" section
+#   The absolute z position in mm to move to before moving to the next
+#   position. The default is two times the z_offset from the probe's
+#   configuration. The minimum safe z height is 3mm.
+# clearance: DEPRECATED - please use safe_z_height instead!
+#   The distance in mm to move up before moving to the next
+#   position. The default is two times the z_offset from the probe's
+#   configuration.
+# position_min: default from "stepper_z:position_min" section.
+#   Minimum valid distance (in mm) used for probing move. The
+#   default is from the Z rail configuration.
+speed: 50
+#   The moving speed in X and Y. The default is 50 mm/s.
+# lift_speed: default from "probe:lift_speed" section
+#   Speed (in mm/s) of the Z axis when lifting the probe between
+#   samples and clearance moves. The default is from the probe's
+#   configuration.
+# probing_speed: default from "stepper_z:homing_speed" section.
+#   The fast probing speed (in mm/s) used, when probing_first_fast
+#   is enabled. The default is from the Z rail configuration.
+# probing_second_speed: default from "stepper_z:second_homing_speed" section.
+#   The slower speed (in mm/s) for probing the recorded samples.
+#   The default is second_homing_speed of the Z rail configuration.
+# probing_retract_dist: default from "stepper_z:homing_retract_dist" section.
+#   Distance to retract (in mm) before probing the next sample.
+#   The default is homing_retract_dist from the Z rail configuration.
+#   Caution: if sensorless homing is used on the Z axis with
+#   homing_retract_dist set to zero, this must be set to a value greater zero.
+probing_first_fast: false
+#   If true, the first probing will be faster by the probing speed.
+#   This is to get down faster and not record the result as a
+#   probing sample. The default is false.
+start_gcode: M401
+#   A list of G-Code commands to run before each calibration command.
+#   See docs/Command_Templates.md for the G-Code format. This can be used to
+#   attach the probe.
+# before_switch_gcode:
+#   A list of G-Code commands to run before to each probing on the
+#   mag-probe. See docs/Command_Templates.md for the G-Code format. This can
+#   be used to attach the probe after probing on the nozzle and before probing
+#   on the mag-probe.
+end_gcode: M402
+#   A list of G-Code commands to run after each calibration command.
+#   See docs/Command_Templates.md for the G-Code format. This can be used to
+#   detach the probe afterwards.

--- a/KlipperConfig/macros.cfg
+++ b/KlipperConfig/macros.cfg
@@ -5,11 +5,11 @@ gcode:
   SAVE_VARIABLE VARIABLE=z_endstop_hit VALUE=0
   G90
   # Note: you need to adjust the position to the center of the button!
-  G1 X58.10 Y238.80 Z5 F8000
+  G1 X64.10 Y238.80 Z5 F8000
   # TODO -> Add retraction and wipe, make sure it is in center!
   M400
   # Note: you need to adjust the position to the center of the button!
-  G1 X58.10 Y238.80 Z3 F500
+  G1 X64.10 Y238.80 Z3 F500
   M400
   G91
   {% set z_count = 500 %}
@@ -32,7 +32,7 @@ gcode:
     {% set Z_PROBE_OFFSET = printer.configfile.settings.probe.z_offset | default(0) | float | round(3) %}
     {% set Z_PRINTBED_OFFSET = printer.save_variables.variables.z_printbed_offset | default(0.4) | float | round(3) %}
 
-    {% if printer['gcode_button pa0'].state == "PRESSED" %}
+    {% if printer['gcode_button z_calibration_button'].state == "PRESSED" %}
         RESPOND TYPE=command MSG="Z-end button hit at {Z_POSITION}"
         SAVE_VARIABLE VARIABLE=z_endstop_hit VALUE={Z_POSITION}
         {% set CALCULATED_Z_PROBE_OFFSET = Z_PROBE_OFFSET + Z_POSITION * -1 - Z_PRINTBED_OFFSET %}

--- a/KlipperConfig/moonraker.conf
+++ b/KlipperConfig/moonraker.conf
@@ -1,7 +1,7 @@
 [server]
 host: 0.0.0.0
 port: 7125
-klippy_uds_address: /home/pi/printer_data/comms/klippy.sock
+klippy_uds_address: ~/printer_data/comms/klippy.sock
 
 [authorization]
 trusted_clients:
@@ -43,7 +43,7 @@ path: ~/fluidd
 
 [update_manager z_calibration]
 type: git_repo
-path: /home/pi/klipper_z_calibration
+path: ~/klipper_z_calibration
 origin: https://github.com/protoloft/klipper_z_calibration.git
 managed_services: klipper
 

--- a/KlipperConfig/printer.cfg
+++ b/KlipperConfig/printer.cfg
@@ -7,18 +7,21 @@
 
 [include fluidd.cfg]
 [include macros.cfg]
+# AutoZ configuration is not done
+# [include autoz.cfg]
 
 
 [exclude_object]
 [gcode_arcs]
 
 [mcu]
+restart_method: command
 # If you are using USB:
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+baud: 250000
 # If you are using UART (make sure to edit the Raspberry Pi config.txt):
-#serial: /dev/ttyAMA0
-restart_method: command
-baud: 115200
+# serial: /dev/ttyAMA0
+# baud: 115200
 
 [printer]
 kinematics: cartesian
@@ -44,9 +47,9 @@ enable_pin: !PA15
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^!PB11
-position_endstop: -10
-position_min: -14
-position_max: 235
+position_endstop: -5.8
+position_min: -5.8
+position_max: 230
 homing_speed: 100
 
 [stepper_y]
@@ -56,8 +59,8 @@ enable_pin: !PA15
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^!PC13
-position_endstop: -2
-position_min: -3
+position_endstop: -1.0
+position_min: -1.0
 position_max: 240
 homing_speed: 100
 
@@ -67,9 +70,13 @@ dir_pin: !PB1
 enable_pin: !PA15
 microsteps: 16
 rotation_distance: 8
+# (1/3) Enable this for PA0 Probe button
+# PA0 is 3mm below Bed?
+# position_endstop: -3
+# Define endstop PIN (z calibration button)
+# endstop_pin: PA0
+# Normal homing behaviour
 endstop_pin: probe:z_virtual_endstop
-#position_endstop: 0
-#endstop_pin: PA0
 position_min: -4
 position_max: 250
 homing_speed: 15
@@ -119,6 +126,8 @@ pid_kd: 1675.16
 pin: PA1
 x_offset : 24.0
 y_offset : 13.35
+# This parameter must be provided.
+z_offset: 1.7
 samples: 3
 samples_result: average
 samples_tolerance_retries: 1
@@ -131,25 +140,32 @@ samples_tolerance_retries : 3
 [bed_mesh]
 speed: 200
 horizontal_move_z: 5
-mesh_min: 14, 11
-mesh_max: 210, 215
-probe_count: 7,7
+# TODO: Improve that
+# min: 0 + relative to probe + 2 (24 + 2),(14 + 2)
+mesh_min: 26, 16
+# max: 230 - relative to probe - 2: (230 - 24 - 2), (230 - 13 - 2)
+mesh_max: 204, 215
+probe_count: 5,5
 mesh_pps: 4,4 
 algorithm: bicubic
 bicubic_tension: 0.2
 
 # Z-home probing, position for z-button
-#[safe_z_home]
+# WARNING! Only enable this if other config for Probe button is done!
+# !!! Otherwise the nozzle will not stop and smash your button / bed !!!
+# (2/3) Enable this for PA0 Probe button
+# [safe_z_home]
 ## Coordinates must be changed to center of your button
-#home_xy_position: 58.10, 238.80
-#speed: 100
-#z_hop: 5
-#z_hop_speed: 15
+# home_xy_position: 64.10, 238.80
+# speed: 100
+# z_hop: 5
+# z_hop_speed: 15
 
-#zhome probing with magnetic probe.
 [safe_z_home]
-# Coordinates of center of the bed
-home_xy_position: 110, 110
+# z-home probing with magnetic probe.
+# Coordinates of left end of the bed, like anycubic firmware does it
+# WARNING! Sensor position has to be over the bed. 
+home_xy_position: 40, 190
 speed: 100
 z_hop: 5
 z_hop_speed: 15
@@ -181,15 +197,17 @@ pin: PB4
 press_gcode: CANCEL_PRINT
 #release_gcode:
 
+# (3/3) Disable this for PA0 Probe button
 # This is for the Anycubic Kobra printers equipped with auto Z-home button
-[gcode_button pa0]
+[gcode_button z_calibration_button]
 pin: PA0
 press_gcode: 
-    QUERY_BUTTON button=pa0
-    #RESPOND TYPE=command MSG='Z-endstop touched!'
-    #M114
+    QUERY_BUTTON button=z_calibration_button
+
+    # RESPOND TYPE=command MSG='Z-endstop touched!'
+    # M114
 release_gcode:
-    QUERY_BUTTON button=pa0
+    QUERY_BUTTON button=z_calibration_button
  
 [respond]
 default_type: echo
@@ -212,25 +230,24 @@ filename: ~/printer_data/config/variables.cfg
 #*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
 #*#
 #*# [probe]
-#*# z_offset = 0.1
 #*#
 #*# [bed_mesh default]
 #*# version = 1
 #*# points =
-#*# 	0.657500, 0.425000, 0.208333, 0.016667, -0.150833, -0.286667, -0.394167
-#*# 	0.843333, 0.585000, 0.330000, 0.130833, -0.039167, -0.153333, -0.261667
-#*# 	1.032500, 0.765000, 0.497500, 0.285833, 0.124167, 0.011667, -0.090000
-#*# 	1.045833, 0.765833, 0.490000, 0.259167, 0.097500, -0.027500, -0.140000
-#*# 	0.975000, 0.683333, 0.411667, 0.191667, 0.015833, -0.103333, -0.207500
-#*# 	0.788333, 0.484167, 0.216667, 0.021667, -0.152500, -0.270833, -0.365833
-#*# 	0.601667, 0.291667, 0.030000, -0.162500, -0.321667, -0.440000, -0.515833
+#*#       -0.110000, -0.125833, -0.133333, -0.120833, -0.062500, 0.035833, 0.164167
+#*#       -0.075833, -0.088333, -0.091667, -0.074167, -0.010833, 0.081667, 0.215000
+#*#       0.003333, -0.015000, -0.029167, -0.022500, 0.040000, 0.121667, 0.246667
+#*#       -0.046667, -0.065833, -0.076667, -0.077500, -0.013333, 0.066667, 0.191667
+#*#       -0.033333, -0.061667, -0.103333, -0.111667, -0.055000, 0.019167, 0.134167
+#*#       -0.215000, -0.255833, -0.285833, -0.283333, -0.221667, -0.142500, -0.020000
+#*#       -0.270000, -0.325000, -0.340833, -0.317500, -0.255833, -0.163333, -0.039167
 #*# x_count = 7
 #*# y_count = 7
 #*# mesh_x_pps = 4
 #*# mesh_y_pps = 4
 #*# algo = bicubic
 #*# tension = 0.2
-#*# min_x = 14.0
-#*# max_x = 209.95999999999998
-#*# min_y = 11.0
-#*# max_y = 215.0
+#*# min_x = 26.0
+#*# max_x = 203.96
+#*# min_y = 16.0
+#*# max_y = 214.95999999999998

--- a/README.md
+++ b/README.md
@@ -39,13 +39,19 @@ This repository provides a comprehensive guide and necessary resources for getti
 ### 2. Flashing Klipper Firmware
 
 - Download the appropriate firmware for your printer from the `KlipperFirmware/` directory.
-- Flash the firmware to the printer's controller board.
+- Flash the firmware to the printer's controller board as described unter `KlipperFirmware/README.md`.
 
 ### 3. Configuring Klipper
 
 - Copy the contents of the `KlipperConfig/` directory to the Raspberry Pi, typically into the `~/printer_data/config` folder.
+- Install moonraker dependencies. Connect via SSH, go to path `cd ~/` and clone dependencies:
+```
+git clone https://github.com/fluidd-core/fluidd-config.git
+git clone https://github.com/protoloft/klipper_z_calibration.git
+./klipper_z_calibration/install.sh
+```
+- Read comments of the `printer.cfg` and edit the configuration files as necessary based on your printer’s hardware. Default: USB mcu is configured
 - Do not forget to do `PROBE_CALIBRATE` and bed mesh leveling.
-- Read comments of the `printer.cfg` and edit the configuration files as necessary based on your printer’s hardware.
 
 ### 4. Setting Up KlipperScreen (Optional)
 


### PR DESCRIPTION
_moonraker.cfg_
Fix: Some paths required user 'pi'. Made all paths relative.

_printer.cfg
macros.cfg_
- Fix mcu config USB Serial device was set, but UART baud;
- Fixed wrong stepper boundaries. X_min=-14 **made knocking sounds!**;
- probe: Added missing and required z_offset;
- Updated bed_mesh cause boundaries were changed, here is room for improovements;
- safe_z_home: Set position to left end of the bed, like anycubic firmware does it;
- Added info and warnings for PA0 probe button config, cause this could **harm the probe button / bed**;
- renamed gcode_button to z_calibration_button

_autoz.cfg_
Pre-configured configuration of klipper_z_calibration which already was added to _moonraker.cfg_.
Untested and still unused dev version.

_README.md_
Added more info for Installation / Configuration